### PR TITLE
Fix warnings from idirs 1.0.

### DIFF
--- a/src/Data/Biapplicative.idr
+++ b/src/Data/Biapplicative.idr
@@ -9,7 +9,7 @@ infixl 4 <<*>>, <<*, *>>, <<**>>
 
 ||| Biapplicatives
 ||| @p the action of the Biapplicative on pairs of objects
-class Bifunctor p => Biapplicative (p : Type -> Type -> Type) where
+interface Bifunctor p => Biapplicative (p : Type -> Type -> Type) where
 
   ||| Lifts two values into a Biapplicative
   |||
@@ -62,6 +62,6 @@ biliftA3 : Biapplicative p =>
   (a -> b -> c -> d) -> (e -> f -> g -> h) -> p a e -> p b f -> p c g -> p d h
 biliftA3 f g a b c = bimap f g <<$>> a <<*>> b <<*>> c
 
-instance Biapplicative Pair where
+implementation Biapplicative Pair where
   bipure a b          = (a, b)
   (f, g) <<*>> (a, b) = (f a, g b)

--- a/src/Data/Bifunctor.idr
+++ b/src/Data/Bifunctor.idr
@@ -4,7 +4,7 @@ module Data.Bifunctor
 
 ||| Bifunctors
 ||| @p The action of the Bifunctor on pairs of objects
-class Bifunctor (p : Type -> Type -> Type) where
+interface Bifunctor (p : Type -> Type -> Type) where
   ||| The action of the Bifunctor on pairs of morphisms
   |||
   ||| ````idris example
@@ -32,9 +32,9 @@ class Bifunctor (p : Type -> Type -> Type) where
   second : (a -> b) -> p c a -> p c b
   second = bimap id
 
-instance Bifunctor Either where
+implementation Bifunctor Either where
   bimap f _ (Left  a) = Left  $ f a
   bimap _ g (Right b) = Right $ g b
 
-instance Bifunctor Pair where
+implementation Bifunctor Pair where
   bimap f g (a, b) = (f a, g b)

--- a/src/Data/Bifunctor/Apply.idr
+++ b/src/Data/Bifunctor/Apply.idr
@@ -28,7 +28,7 @@ infixl 4 <<$>>, <<&>>, <<.>>, <<., .>>, <<..>>
 
 ||| Biapplys (not to be confused with Biapplicatives)
 ||| @p The action of the Biapply on pairs of objects
-class Bifunctor p => Biapply (p : Type -> Type -> Type) where
+interface Bifunctor p => Biapply (p : Type -> Type -> Type) where
 
   ||| Applys a Bifunctor of functions to another Bifunctor of the same type
   |||
@@ -86,5 +86,5 @@ bilift3 f g a b c = bimap f g <<$>> a <<.>> b <<.>> c
 (<<..>>): Biapply p => p a c -> p (a -> b) (c -> d) -> p b d
 (<<..>>) = flip (<<.>>)
 
-instance Biapply Pair where
+implementation Biapply Pair where
   (f, g) <<.>> (a, b) = (f a, g b)

--- a/src/Data/Bifunctor/Biff.idr
+++ b/src/Data/Bifunctor/Biff.idr
@@ -20,29 +20,29 @@ record Biffed (p : Type -> Type -> Type) (f : Type -> Type) (g : Type -> Type)
   constructor Biff
   runBiff : p (f a) (g b)
 
-instance (Bifunctor p, Functor f, Functor g) => Bifunctor (Biffed p f g) where
+implementation (Bifunctor p, Functor f, Functor g) => Bifunctor (Biffed p f g) where
   bimap f g = Biff . bimap (map f) (map g) . runBiff
 
-instance (Bifunctor p, Functor g) => Functor (Biffed p f g a) where
+implementation (Bifunctor p, Functor g) => Functor (Biffed p f g a) where
   map f = Biff . second (map f) . runBiff
 
-instance (Biapplicative p, Applicative f, Applicative g) =>
+implementation (Biapplicative p, Applicative f, Applicative g) =>
          Biapplicative (Biffed p f g) where
   bipure a b                = Biff $ bipure (pure a) (pure b)
   (Biff fg) <<*>> (Biff xy) = Biff $ bimap (<*>) (<*>) fg <<*>> xy
 
-instance (Bifoldable p, Foldable f, Foldable g) =>
+implementation (Bifoldable p, Foldable f, Foldable g) =>
          Bifoldable (Biffed p f g) where
   bifoldMap f g = bifoldMap (concatMap f) (concatMap g) . runBiff
 
-instance (Bifoldable p, Foldable f, Foldable g) =>
+implementation (Bifoldable p, Foldable f, Foldable g) =>
          Foldable (Biffed p f g a) where
   foldr = bifoldr (flip const)
 
-instance (Bitraversable p, Traversable f, Traversable g) =>
+implementation (Bitraversable p, Traversable f, Traversable g) =>
          Bitraversable (Biffed p f g) where
   bitraverse f g = map Biff . bitraverse (traverse f) (traverse g) . runBiff
 
-instance (Bitraversable p, Traversable f, Traversable g) =>
+implementation (Bitraversable p, Traversable f, Traversable g) =>
          Traversable (Biffed p f g a) where
   traverse f = map Biff . bitraverse pure (traverse f) . runBiff

--- a/src/Data/Bifunctor/Clown.idr
+++ b/src/Data/Bifunctor/Clown.idr
@@ -15,24 +15,24 @@ record Clowned (p : Type -> Type) a b where
   constructor Clown
   runClown : p a
 
-instance Functor f => Bifunctor (Clowned f) where
+implementation Functor f => Bifunctor (Clowned f) where
   bimap f = const $ Clown . map f . runClown
 
-instance Functor (Clowned f a) where
+implementation Functor (Clowned f a) where
   map = const $ Clown . runClown
 
-instance Applicative f => Biapplicative (Clowned f) where
+implementation Applicative f => Biapplicative (Clowned f) where
   bipure                    = const . Clown . pure
   (Clown a) <<*>> (Clown b) = Clown $ a <*> b
 
-instance Foldable t => Bifoldable (Clowned t) where
+implementation Foldable t => Bifoldable (Clowned t) where
   bifoldMap f = const $ concatMap f . runClown
 
-instance Foldable (Clowned f a) where
+implementation Foldable (Clowned f a) where
   foldr = const const
 
-instance Traversable t => Bitraversable (Clowned t) where
+implementation Traversable t => Bitraversable (Clowned t) where
   bitraverse f = const $ map Clown . traverse f . runClown
 
-instance Traversable (Clowned t a) where
+implementation Traversable (Clowned t a) where
   traverse = const $ pure . Clown . runClown

--- a/src/Data/Bifunctor/Flip.idr
+++ b/src/Data/Bifunctor/Flip.idr
@@ -13,21 +13,21 @@ record Flip (p : Type -> Type -> Type) b a where
   constructor ToFlip
   runFlip : p a b
 
-instance Bifunctor p => Bifunctor (Flip p) where
+implementation Bifunctor p => Bifunctor (Flip p) where
   bimap f g = ToFlip . bimap g f . runFlip
 
-instance Bifunctor p => Functor (Flip p a) where
+implementation Bifunctor p => Functor (Flip p a) where
   map f = ToFlip . first f . runFlip
 
-instance Biapply p => Biapply (Flip p) where
+implementation Biapply p => Biapply (Flip p) where
   (ToFlip fg) <<.>> (ToFlip xy) = ToFlip $ fg <<.>> xy
 
-instance Biapplicative p => Biapplicative (Flip p) where
+implementation Biapplicative p => Biapplicative (Flip p) where
   bipure a b                    = ToFlip $ bipure b a
   (ToFlip fg) <<*>> (ToFlip xy) = ToFlip $ fg <<*>> xy
 
-instance Bifoldable p => Bifoldable (Flip p) where
+implementation Bifoldable p => Bifoldable (Flip p) where
   bifoldMap f g = bifoldMap g f . runFlip
 
-instance Bitraversable p => Bitraversable (Flip p) where
+implementation Bitraversable p => Bitraversable (Flip p) where
   bitraverse f g = map ToFlip . bitraverse g f . runFlip

--- a/src/Data/Bifunctor/Join.idr
+++ b/src/Data/Bifunctor/Join.idr
@@ -19,15 +19,15 @@ record Joined (p : Type -> Type -> Type) a where
   constructor Join
   runJoined : p a a
 
-instance Bifunctor p => Functor (Joined p) where
+implementation Bifunctor p => Functor (Joined p) where
   map f (Join a) = Join $ bimap f f a
 
-instance Biapplicative p => Applicative (Joined p) where
+implementation Biapplicative p => Applicative (Joined p) where
   pure a                = Join $ bipure a a
   (Join f) <*> (Join x) = Join $ f <<*>> x
 
-instance Bifoldable p => Foldable (Joined p) where
+implementation Bifoldable p => Foldable (Joined p) where
   foldr f z = bifoldr f f z . runJoined
 
-instance Bitraversable p => Traversable (Joined p) where
+implementation Bitraversable p => Traversable (Joined p) where
   traverse f (Join a) = map Join $ bitraverse f f a

--- a/src/Data/Bifunctor/Joker.idr
+++ b/src/Data/Bifunctor/Joker.idr
@@ -15,24 +15,24 @@ record Joked (p : Type -> Type) a b where
   constructor Joker
   runJoker : p b
 
-instance Functor f => Bifunctor (Joked f) where
+implementation Functor f => Bifunctor (Joked f) where
   bimap _ g = Joker . map g . runJoker
 
-instance Functor f => Functor (Joked f b) where
+implementation Functor f => Functor (Joked f b) where
   map g = Joker . map g . runJoker
 
-instance Applicative f => Biapplicative (Joked f) where
+implementation Applicative f => Biapplicative (Joked f) where
   bipure                    = const $ Joker . pure
   (Joker a) <<*>> (Joker b) = Joker $ a <*> b
 
-instance Foldable t => Bifoldable (Joked t) where
+implementation Foldable t => Bifoldable (Joked t) where
   bifoldMap _ g = concatMap g . runJoker
 
-instance Foldable t => Foldable (Joked t a) where
+implementation Foldable t => Foldable (Joked t a) where
   foldr f z = foldr f z . runJoker
 
-instance Traversable t => Bitraversable (Joked t) where
+implementation Traversable t => Bitraversable (Joked t) where
   bitraverse _ g = map Joker . traverse g . runJoker
 
-instance Traversable t => Traversable (Joked t a) where
+implementation Traversable t => Traversable (Joked t a) where
   traverse g = map Joker . traverse g . runJoker

--- a/src/Data/Bifunctor/Tannen.idr
+++ b/src/Data/Bifunctor/Tannen.idr
@@ -19,25 +19,25 @@ record Tanned (f : Type -> Type) (p : Type -> Type -> Type) a b where
   constructor Tannen
   runTannen : f (p a b)
 
-instance (Bifunctor p, Functor f) => Bifunctor (Tanned f p) where
+implementation (Bifunctor p, Functor f) => Bifunctor (Tanned f p) where
   bimap f g = Tannen . map (bimap f g) . runTannen
 
-instance (Bifunctor p, Functor f) => Functor (Tanned f p a) where
+implementation (Bifunctor p, Functor f) => Functor (Tanned f p a) where
   map f = Tannen . map (second f) . runTannen
 
-instance (Biapplicative p, Applicative f) => Biapplicative (Tanned f p) where
+implementation (Biapplicative p, Applicative f) => Biapplicative (Tanned f p) where
   bipure a b = Tannen . pure $ bipure a b
   (Tannen fg) <<*>> (Tannen xy) = Tannen $ (map (<<*>>) fg) <*> xy
 
-instance (Foldable f, Bifoldable p) => Bifoldable (Tanned f p) where
+implementation (Foldable f, Bifoldable p) => Bifoldable (Tanned f p) where
   bifoldMap f g = (foldr ((<+>) . (bifoldMap f g)) neutral) . runTannen
 
-instance (Foldable f, Bifoldable p) => Foldable (Tanned f p a) where
+implementation (Foldable f, Bifoldable p) => Foldable (Tanned f p a) where
   foldr f z t = applyEndo ((((concatMap . bifoldMap (const neutral)
                                                   $ Endo . f)) . runTannen) t) z
 
-instance (Traversable f, Bitraversable p) => Bitraversable (Tanned f p) where
+implementation (Traversable f, Bitraversable p) => Bitraversable (Tanned f p) where
   bitraverse f g = map Tannen . traverse (bitraverse f g) . runTannen
 
-instance (Traversable f, Bitraversable p) => Traversable (Tanned f p a) where
+implementation (Traversable f, Bitraversable p) => Traversable (Tanned f p a) where
   traverse f = map Tannen . traverse (bitraverse pure f) . runTannen

--- a/src/Data/Bifunctor/Wrapped.idr
+++ b/src/Data/Bifunctor/Wrapped.idr
@@ -19,27 +19,27 @@ record Wrapped (p : Type -> Type -> Type) a b where
   constructor Wrap
   unwrap : p a b
 
-instance Bifunctor p => Bifunctor (Wrapped p) where
+implementation Bifunctor p => Bifunctor (Wrapped p) where
   bimap f g = Wrap . bimap f g . unwrap
 
-instance Bifunctor p => Functor (Wrapped p a) where
+implementation Bifunctor p => Functor (Wrapped p a) where
   map f = Wrap . second f . unwrap
 
-instance Biapply p => Biapply (Wrapped p) where
+implementation Biapply p => Biapply (Wrapped p) where
   (Wrap fg) <<.>> (Wrap xy) = Wrap (fg <<.>> xy)
 
-instance Biapplicative p => Biapplicative (Wrapped p) where
+implementation Biapplicative p => Biapplicative (Wrapped p) where
   bipure a b                = Wrap $ bipure a b
   (Wrap fg) <<*>> (Wrap xy) = Wrap $ fg <<*>> xy
 
-instance Bifoldable p => Bifoldable (Wrapped p) where
+implementation Bifoldable p => Bifoldable (Wrapped p) where
   bifoldMap f g = bifoldMap f g . unwrap
 
-instance Bifoldable p => Foldable (Wrapped p a) where
+implementation Bifoldable p => Foldable (Wrapped p a) where
   foldr f z = bifoldr (const $ const z) f z . unwrap
 
-instance Bitraversable p => Bitraversable (Wrapped p) where
+implementation Bitraversable p => Bitraversable (Wrapped p) where
   bitraverse f g = map Wrap . bitraverse f g . unwrap
 
-instance Bitraversable p => Traversable (Wrapped p a) where
+implementation Bitraversable p => Traversable (Wrapped p a) where
   traverse f = map Wrap . bitraverse pure f . unwrap

--- a/src/Data/Bimonad.idr
+++ b/src/Data/Bimonad.idr
@@ -10,7 +10,7 @@ infixl 4 >>==
 ||| Bimonads
 ||| @p the action of the first Bifunctor component on pairs of objects
 ||| @q the action of the second Bifunctor component on pairs of objects
-class (Biapplicative p, Biapplicative q) =>
+interface (Biapplicative p, Biapplicative q) =>
       Bimonad (p : Type -> Type -> Type) (q : Type -> Type -> Type) where
 
   ||| The equivalent of `join` for standard Monads
@@ -43,5 +43,5 @@ class (Biapplicative p, Biapplicative q) =>
 biunit : Bimonad p q => a -> b -> (p a b, q a b)
 biunit a b = (bipure a b, bipure a b)
 
-instance Bimonad Pair Pair where
+implementation Bimonad Pair Pair where
   bijoin = bimap fst snd

--- a/src/Data/Bitraversable.idr
+++ b/src/Data/Bitraversable.idr
@@ -8,7 +8,7 @@ import Control.Monad.Identity
 
 ||| Bitraversables
 ||| @t A bifunctor and bifoldable object which can be traversed by monads
-class (Bifunctor t, Bifoldable t) =>
+interface (Bifunctor t, Bifoldable t) =>
       Bitraversable (t : Type -> Type -> Type) where
 
   bitraverse : Applicative f => (a -> f c) -> (b -> f d) -> t a b -> f (t c d)
@@ -38,10 +38,10 @@ record StateL s a where
   constructor SL
   runStateL : s -> (s, a)
 
-instance Functor (StateL s) where
+implementation Functor (StateL s) where
   map f (SL k) = SL $ \s => let (s', v) = k s in (s', f v)
 
-instance Applicative (StateL s) where
+implementation Applicative (StateL s) where
   pure x = SL (\s => (s, x))
   (SL kf) <*> (SL kv) = SL $ \s => let (s', f) = kf s; (s'', v') = kv s'
                                    in (s'', f v')
@@ -61,10 +61,10 @@ record StateR s a where
   constructor SR
   runStateR : s -> (s, a)
 
-instance Functor (StateR s) where
+implementation Functor (StateR s) where
   map f (SR k) = SR $ \s => let (s', v) = k s in (s', f v)
 
-instance Applicative (StateR s) where
+implementation Applicative (StateR s) where
   pure x = SR $ \s => (s, x)
   (SR kf) <*> (SR kv) = SR $ \s => let (s', v) = kv s; (s'', f) = kf s'
                                    in (s'', f v)
@@ -79,9 +79,9 @@ bimapAccumR : Bitraversable t => (a -> b -> (a, c)) -> (a -> d -> (a, e)) ->
                                  a -> t b d -> (a, t c e)
 bimapAccumR f g s t = biforAccumR s t f g
 
-instance Bitraversable Pair where
+implementation Bitraversable Pair where
   bitraverse f g (a, b) = map MkPair (f a) <*> (g b)
 
-instance Bitraversable Either where
+implementation Bitraversable Either where
   bitraverse f _ (Left a)  = map Left  $ f a
   bitraverse _ g (Right b) = map Right $ g b


### PR DESCRIPTION
The 4 warnings were around deprecated keywords and implicit binding.

./Data/Bifoldable.idr:11:8:
Data.Bifoldable.toDual has a name which may be implicitly bound.
This is likely to lead to problems!

The 'instance' keyword is deprecated. Use 'implementation' (or omit it) instead.

./Data/Bifoldable.idr:73:10:Use of deprecated name Prelude.Monad.return
Please use `pure`, which is equivalent.

The 'class' keyword is deprecated. Use 'interface' instead.